### PR TITLE
Move the AllowedHosts option to a production only state.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,13 @@ Content-Security-Policy: default-src 'self'
 ```
 
 ###Set the `MARTINI_ENV` environment variable to `production` when deploying!
-If you don't, the SSLRedirect and STS Header will not work. This allows you to work in development/test mode and not have any annoying redirects to HTTPS (ie. development can happen on http). If this is not the behavior you're expecting, see the `DisableProdCheck` below in the options.
+If you don't, the AllowedHosts, SSLRedirect, and STS Header will not be in effect. This allows you to work in development/test mode and not have any annoying redirects to HTTPS (ie. development can happen on http), or block `localhost` has a bad host. If this is not the behavior you're expecting, see the `DisableProdCheck` below in the options.
 
 You can also disable the production check for testing like so:
 ```go
 //...
 m.Use(secure.Secure(secure.Options{
+    AllowedHosts: []string{"example.com", "ssl.example.com"},
     SSLRedirect: true,
     STSSeconds: 315360000,
     DisableProdCheck: martini.Env == martini.Test,
@@ -77,7 +78,7 @@ m.Use(secure.Secure(secure.Secure{
   ContentTypeNosniff: true, // If ContentTypeNosniff is true, adds the X-Content-Type-Options header with the value `nosniff`. Default is false.
   BrowserXssFilter: true, // If BrowserXssFilter is true, adds the X-XSS-Protection header with the value `1; mode=block`. Default is false.
   ContentSecurityPolicy: "default-src 'self'", // ContentSecurityPolicy allows the Content-Security-Policy header value to be set with a custom value. Default is "".
-  DisableProdCheck: true, // This will ignore our production check, and will follow the SSLRedirect and STSSeconds/STSIncludeSubdomains options... even in development! This would likely only be used to mimic a production environment on your local development machine.
+  DisableProdCheck: true, // This will ignore our production check, and will follow the AllowedHosts, SSLRedirect, and STSSeconds/STSIncludeSubdomains options... even in development! This would likely only be used to mimic a production environment on your local development machine.
 }))
 // ...
 ```

--- a/secure.go
+++ b/secure.go
@@ -67,8 +67,8 @@ type Options struct {
 	BrowserXssFilter bool
 	// ContentSecurityPolicy allows the Content-Security-Policy header value to be set with a custom value. Default is "".
 	ContentSecurityPolicy string
-	// When developing, the SSL and STS options can cause some unwanted effects. Usually testing happens on http, not https... we check `if martini.Env == martini.Prod`.
-	// If you would like your development environment to mimic production with complete SSL redirects and STS headers, set this to true. Default if false.
+	// When developing, the AllowedHosts, SSL, and STS options can cause some unwanted effects. Usually testing happens on http, not https, and one localhost, not your production domain... we check `if martini.Env == martini.Prod`.
+	// If you would like your development environment to mimic production with complete Host blocking, SSL redirects, and STS headers, set this to true. Default if false.
 	DisableProdCheck bool
 }
 
@@ -100,7 +100,7 @@ func Secure(opt Options) martini.Handler {
 }
 
 func applyAllowedHosts(opt Options, res http.ResponseWriter, req *http.Request) {
-	if len(opt.AllowedHosts) > 0 {
+	if len(opt.AllowedHosts) > 0 && (martini.Env == martini.Prod || opt.DisableProdCheck == true) {
 		isGoodHost := false
 		for _, allowedHost := range opt.AllowedHosts {
 			if strings.EqualFold(allowedHost, req.Host) {

--- a/secure_test.go
+++ b/secure_test.go
@@ -30,6 +30,7 @@ func Test_No_Config(t *testing.T) {
 
 func Test_No_AllowHosts(t *testing.T) {
 	m := martini.Classic()
+	martini.Env = martini.Prod
 	m.Use(Secure(Options{
 		AllowedHosts: []string{},
 	}))
@@ -50,6 +51,7 @@ func Test_No_AllowHosts(t *testing.T) {
 
 func Test_Good_Single_AllowHosts(t *testing.T) {
 	m := martini.Classic()
+	martini.Env = martini.Prod
 	m.Use(Secure(Options{
 		AllowedHosts: []string{"www.example.com"},
 	}))
@@ -70,6 +72,7 @@ func Test_Good_Single_AllowHosts(t *testing.T) {
 
 func Test_Bad_Single_AllowHosts(t *testing.T) {
 	m := martini.Classic()
+	martini.Env = martini.Prod
 	m.Use(Secure(Options{
 		AllowedHosts: []string{"sub.example.com"},
 	}))
@@ -89,6 +92,7 @@ func Test_Bad_Single_AllowHosts(t *testing.T) {
 
 func Test_Good_Multiple_AllowHosts(t *testing.T) {
 	m := martini.Classic()
+	martini.Env = martini.Prod
 	m.Use(Secure(Options{
 		AllowedHosts: []string{"www.example.com", "sub.example.com"},
 	}))
@@ -109,6 +113,7 @@ func Test_Good_Multiple_AllowHosts(t *testing.T) {
 
 func Test_Bad_Multiple_AllowHosts(t *testing.T) {
 	m := martini.Classic()
+	martini.Env = martini.Prod
 	m.Use(Secure(Options{
 		AllowedHosts: []string{"www.example.com", "sub.example.com"},
 	}))
@@ -124,6 +129,47 @@ func Test_Bad_Multiple_AllowHosts(t *testing.T) {
 	m.ServeHTTP(res, req)
 
 	expect(t, res.Code, http.StatusInternalServerError)
+}
+
+func Test_AllowHosts_Dev_Mode_But_DisableProdCheck(t *testing.T) {
+	m := martini.Classic()
+	martini.Env = martini.Dev
+	m.Use(Secure(Options{
+		AllowedHosts:     []string{"www.example.com", "sub.example.com"},
+		DisableProdCheck: true,
+	}))
+
+	m.Get("/foo", func() string {
+		return "bar"
+	})
+
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/foo", nil)
+	req.Host = "www3.example.com"
+
+	m.ServeHTTP(res, req)
+
+	expect(t, res.Code, http.StatusInternalServerError)
+}
+
+func Test_AllowHosts_Dev_Mode(t *testing.T) {
+	m := martini.Classic()
+	martini.Env = martini.Dev
+	m.Use(Secure(Options{
+		AllowedHosts: []string{"www.example.com", "sub.example.com"},
+	}))
+
+	m.Get("/foo", func() string {
+		return "bar"
+	})
+
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/foo", nil)
+	req.Host = "www3.example.com"
+
+	m.ServeHTTP(res, req)
+
+	expect(t, res.Code, http.StatusOK)
 }
 
 func Test_SSL(t *testing.T) {


### PR DESCRIPTION
It was annoying to have the AllowedHosts take effect in a development environment. I changed the behaviour so this option will only be effective in production.
