### PR TITLE
Sniff headers for forwarded-proto to detect clients requested protocol

### DIFF
--- a/secure.go
+++ b/secure.go
@@ -118,7 +118,8 @@ func applyAllowedHosts(opt Options, res http.ResponseWriter, req *http.Request) 
 func applySSL(opt Options, res http.ResponseWriter, req *http.Request) {
 	if opt.SSLRedirect && (martini.Env == martini.Prod || opt.DisableProdCheck == true) {
 		isSSL := false
-		if strings.EqualFold(req.URL.Scheme, "https") || req.TLS != nil {
+		forwarded := req.Header.Get("X-Forwarded-Proto")
+		if strings.EqualFold(req.URL.Scheme, "https") || req.TLS != nil || strings.EqualFold(forwarded, "https") {
 			isSSL = true
 		} else {
 			for hKey, hVal := range opt.SSLProxyHeaders {


### PR DESCRIPTION
This is useful on heroku where dynos and the load balancer always communicate over http regardless of what the client requested. Without this the client will be sent into an infinite loop
