### PR TITLE
HTTP redirect to HTTPS example

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ func main() {
 	martini.Env = martini.Prod
 
 	m := martini.New()
+
+	m.Use(secure.Secure(secure.Options{
+    SSLRedirect:  true,
+    SSLHost:      "localhost:8443",  // This is optional in production. The default behavior is to just redirect the request to the https protocol. Example: http://github.com/some_page would be redirected to https://github.com/some_page.
+	}))
+
 	m.Use(martini.Logger())
 	m.Use(martini.Recovery())
 	m.Use(martini.Static("public"))
@@ -112,11 +118,6 @@ func main() {
 	r.Get("/", func() string {
 		return "Hello world!"
 	})
-
-	m.Use(secure.Secure(secure.Options{
-    SSLRedirect:  true,
-    SSLHost:      "localhost:8443",  // This is optional in production. The default behavior is to just redirect the request to the https protocol. Example: http://github.com/some_page would be redirected to https://github.com/some_page.
-	}))
 
 	// HTTP
 	go func() {

--- a/README.md
+++ b/README.md
@@ -101,14 +101,12 @@ func main() {
 	martini.Env = martini.Prod
 
 	m := martini.New()
-
+	m.Use(martini.Logger())
+	m.Use(martini.Recovery())
 	m.Use(secure.Secure(secure.Options{
     SSLRedirect:  true,
     SSLHost:      "localhost:8443",  // This is optional in production. The default behavior is to just redirect the request to the https protocol. Example: http://github.com/some_page would be redirected to https://github.com/some_page.
 	}))
-
-	m.Use(martini.Logger())
-	m.Use(martini.Recovery())
 	m.Use(martini.Static("public"))
 
 	r := martini.NewRouter()

--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ func main() {
 	m.Use(martini.Logger())
 	m.Use(martini.Recovery())
 	m.Use(secure.Secure(secure.Options{
-    SSLRedirect:  true,
-    SSLHost:      "localhost:8443",  // This is optional in production. The default behavior is to just redirect the request to the https protocol. Example: http://github.com/some_page would be redirected to https://github.com/some_page.
+		SSLRedirect:  true,
+		SSLHost:      "localhost:8443",  // This is optional in production. The default behavior is to just redirect the request to the https protocol. Example: http://github.com/some_page would be redirected to https://github.com/some_page.
 	}))
 	m.Use(martini.Static("public"))
 


### PR DESCRIPTION
HTTPS redirection for static files didn't work with the example code under "Redirecting HTTP to HTTPS". I changed the code to correspond with the instructions given in the first sentence of the README file: "Make sure to include the secure middleware as close to the top as possible". Now the code works as expected.