### PR TITLE
Use 307 response code for redirects on requests other than GET and HE…

### DIFF
--- a/secure.go
+++ b/secure.go
@@ -138,7 +138,11 @@ func applySSL(opt Options, res http.ResponseWriter, req *http.Request) {
 				url.Host = opt.SSLHost
 			}
 
-			http.Redirect(res, req, url.String(), http.StatusMovedPermanently)
+			if req.Method != "" && req.Method != "GET" && req.Method != "HEAD" {
+				http.Redirect(res, req, url.String(), http.StatusTemporaryRedirect)
+			} else {
+				http.Redirect(res, req, url.String(), http.StatusMovedPermanently)
+			}
 		}
 	}
 }


### PR DESCRIPTION
For redirecting http methods other than GET and HEAD, response 307 should be used.  This prevents bad behavior in most browsers that respond to a redirect via a 302 with a GET rather than the identical method that was used.

See this discussion for reference:
http://softwareengineering.stackexchange.com/questions/99894/why-doesnt-http-have-post-redirect